### PR TITLE
寸劇時のステージセレクトBGMなるバグ修正

### DIFF
--- a/Assets/Scripts/StageContents/StageSelect/StageSelectBGM.cs
+++ b/Assets/Scripts/StageContents/StageSelect/StageSelectBGM.cs
@@ -105,6 +105,11 @@ namespace SamuraiSoccer.StageContents.StageSelect
             while (totalTime < delayTime)
             {
                 token.ThrowIfCancellationRequested();
+                if (SoundMaster.Instance.BGMIndex != SoundMaster.STAGE_SELECT_BGM_INDEX)
+                {
+                    source.volume = 0;
+                    return;
+                }
                 source.volume = (delayTime - totalTime) / delayTime;
                 totalTime += Time.deltaTime;
                 await UniTask.Yield();
@@ -118,6 +123,11 @@ namespace SamuraiSoccer.StageContents.StageSelect
             while (totalTime < delayTime)
             {
                 token.ThrowIfCancellationRequested();
+                if (SoundMaster.Instance.BGMIndex != SoundMaster.STAGE_SELECT_BGM_INDEX)
+                {
+                    source.volume = 0;
+                    return;
+                }
                 source.volume = totalTime / delayTime;
                 totalTime += Time.deltaTime;
                 await UniTask.Yield();

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -147,9 +147,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"


### PR DESCRIPTION
# 起きたこと

ステージセレクトで会話があるところで即会話に入ると、各国のそれぞれの音楽が会話中に遅れてなり始める。

# 修正方針

対応漏れていたFadeIn / FadeOutのところを修正。詳細はコメント。
